### PR TITLE
Make `AuthenticationException` public

### DIFF
--- a/SteamKit2/SteamKit2/Steam/Handlers/SteamAuthentication/AuthenticationException.cs
+++ b/SteamKit2/SteamKit2/Steam/Handlers/SteamAuthentication/AuthenticationException.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace SteamKit2
 {
-    internal class AuthenticationException : Exception
+    public class AuthenticationException : Exception
     {
         /// <summary>
         /// 


### PR DESCRIPTION
`StartPolling()` can throw `AuthenticationException` e.g. in rate limited case, if we want to allow callers to handle this (e.g. by adding delay before next try), we must make it public.